### PR TITLE
Allow configured path to hologram binary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Type: `String`
 
 The path to your hologram config file.
 
+#### options.bin
+Type: `String`
+*Optional*
+
+The path to your hologram binary installation.
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 

--- a/tasks/hologram.js
+++ b/tasks/hologram.js
@@ -16,9 +16,10 @@ module.exports = function (grunt) {
 
     var options = this.options();
     var configPath;
+    var cmd = options.bin || 'hologram';
 
     try {
-      which.sync('hologram');
+      grunt.file.isFile(cmd) || which.sync('hologram');
     } catch (err) {
       return grunt.warn(
         '\nYou need to have Hologram installed and in your PATH for this task to work.\n' +
@@ -41,7 +42,7 @@ module.exports = function (grunt) {
     }
 
     // Run hologram
-    var cp = spawn('hologram', [configPath], {stdio: 'inherit'});
+    var cp = spawn(cmd, [configPath], {stdio: 'inherit'});
 
     cp.on('error', function (err) {
       grunt.warn(err);


### PR DESCRIPTION
This simple change allows you to specify the path of the hologram binary. It errs on the notion that a configured path will be identifiable as a file on disk, whereas the default "hologram" is in the path.
